### PR TITLE
feat(api): update effects shape, now an array of maps

### DIFF
--- a/src/combine-reducers.ts
+++ b/src/combine-reducers.ts
@@ -1,10 +1,10 @@
 import { combineReducers as reduxCombineReducers, Action } from 'redux'
 import { hasFX, fx, StateWithFx } from './helpers'
-import { FXReducer, BatchEffects } from './types'
+import { FXReducer, Effects } from './types'
 import mapValues from 'lodash.mapvalues'
 
 export interface ReducersMapObject {
-  [key: string]: FXReducer<any, Action>
+  [key: string]: FXReducer<any>
 }
 
 function combineReducers<A extends Action>(reducers: ReducersMapObject) {
@@ -12,16 +12,12 @@ function combineReducers<A extends Action>(reducers: ReducersMapObject) {
 
   return function(state: any, action: A): StateWithFx<any> {
     const newStateWithFx = reducer(state, action)
-    let batchEffects: BatchEffects = []
+    let batchEffects: Effects = []
 
     const newState = mapValues(newStateWithFx, (value: any) => {
       if (hasFX(value)) {
         let { state, effects } = value
-        if (Array.isArray(effects)) {
-          batchEffects = batchEffects.concat(effects)
-        } else {
-          batchEffects.push(effects)
-        }
+        batchEffects = batchEffects.concat(effects)
 
         return state
       }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,8 +1,8 @@
-import { Effects, BatchEffects } from './types'
+import { Effects } from './types'
 
 export interface StateWithFx<S> {
   state: S
-  effects: Effects | BatchEffects
+  effects: Effects
 }
 
 export class StateWithFx<S> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,24 +1,23 @@
-import { Action, StoreEnhancer, Dispatch, Store } from 'redux'
+import { Action, StoreEnhancer, Dispatch, Store, Reducer } from 'redux'
 import { StateWithFx } from './helpers'
 
-export type Effects = { [key: string]: any }
-
-export type BatchEffects = Effects[]
+export type Effect = { effect: string; [key: string]: any }
+export type Effects = Effect[]
 
 export interface StoreCreator {
   <S, A extends Action>(
-    reducer: FXReducer<S, A>,
+    reducer: FXReducer<S>,
     enhancer?: StoreEnhancer<S>
   ): FXStore<S>
   <S, A extends Action>(
-    reducer: FXReducer<S, A>,
+    reducer: FXReducer<S>,
     preloadedState: S,
     enhancer?: StoreEnhancer<S>
   ): FXStore<S>
 }
 
-export interface FXReducer<S, A> {
-  (state: S | undefined, action: A): S | StateWithFx<S>
+export interface FXReducer<S> {
+  (state: S | undefined, action: Action): S | StateWithFx<S>
 }
 
 export interface FXHandler<S> {
@@ -37,4 +36,5 @@ export type QueuedFX = [string, FXParams]
 
 export interface FXStore<S> extends Store<S> {
   registerFX(id: string, handler: FXHandler<S>): void
+  replaceEffectfulReducer(reducer: FXReducer<S>): void
 }

--- a/test/combine-reducers.test.ts
+++ b/test/combine-reducers.test.ts
@@ -30,16 +30,16 @@ const effectfulReducer = combineReducers({
   reducer1: (state: number = 0, action: Action) => {
     switch (action.type) {
       case 'testFx1':
-        return fx(state + 1, { sideFx1: action.payload })
+        return fx(state + 1, [{ effect: 'sideFx1', ...action.payload }])
       case 'testFx2':
-        return fx(state + 1, { sideFx2: action.payload })
+        return fx(state + 1, [{ effect: 'sideFx2', ...action.payload }])
       case 'batchedFx':
         return fx(state, [
-          { sideFx1: {} },
-          { sideFx1: {} },
-          { sideFx2: {} },
-          { sideFx2: {} },
-          { sideFx2: {} }
+          { effect: 'sideFx1' },
+          { effect: 'sideFx1' },
+          { effect: 'sideFx2' },
+          { effect: 'sideFx2' },
+          { effect: 'sideFx2' }
         ])
       default:
         return state

--- a/test/redux-data-fx.test.ts
+++ b/test/redux-data-fx.test.ts
@@ -53,110 +53,94 @@ let localStorage = new Storage()
 function reducer(state: State = initialState, action: Action) {
   switch (action.type) {
     case 'wait':
-      return fx(state, {
-        timeout: {
+      return fx(state, [
+        {
+          effect: 'timeout',
           value: 50,
           action: 'increment',
           payload: {}
         }
-      })
+      ])
 
     case 'increment':
       return { value: state.value + 1 }
 
     case 'global':
-      return fx(state, {
-        global: {
+      return fx(state, [
+        {
+          effect: 'global',
           test: 1,
           ok: 'cool'
         }
-      })
+      ])
 
     case 'storageSet':
-      return fx(state, {
-        localStorage: {
+      return fx(state, [
+        {
+          effect: 'localStorage',
           set: {
             key1: 'value1',
             key2: 'value2'
           }
         }
-      })
+      ])
 
     case 'storageRemove':
-      return fx(
-        { value: 1000 },
+      return fx({ value: 1000 }, [
         {
-          localStorage: {
-            remove: ['key1', 'key2']
-          }
+          effect: 'localStorage',
+          remove: ['key1', 'key2']
         }
-      )
+      ])
 
     case 'testSideFx1':
-      return fx(state, {
-        sideFx1: action.payload
-      })
+      return fx(state, [{ effect: 'sideFx1', ...action.payload }])
 
     case 'testSideFx2':
-      return fx(state, {
-        sideFx2: action.data
-      })
+      return fx(state, [{ effect: 'sideFx2', ...action.data }])
 
     case 'undefinedFx':
-      return fx(state, {
-        undefinedFx: { a: 1 }
-      })
+      return fx(state, [{ effect: 'undefinedFx', a: 1 }])
 
     case 'batchStorage':
       return fx({ value: 50 }, [
         {
-          localStorage: {
-            set: {
-              a: 1,
-              b: 2
-            }
+          effect: 'localStorage',
+          set: {
+            a: 1,
+            b: 2
           }
         },
         {
-          localStorage: {
-            set: {
-              c: 3,
-              d: 4
-            }
+          effect: 'localStorage',
+          set: {
+            c: 3,
+            d: 4
           }
         },
         {
-          localStorage: {
-            set: {
-              e: 5,
-              f: 6
-            }
+          effect: 'localStorage',
+          set: {
+            e: 5,
+            f: 6
           }
         }
       ])
 
     case 'flow1':
-      return fx(
-        { value: 2020 },
-        {
-          log: { text: 'step1' },
-          dispatch: { actions: [{ type: 'flow2' }] }
-        }
-      )
+      return fx({ value: 2020 }, [
+        { effect: 'log', text: 'step1' },
+        { effect: 'dispatch', actions: [{ type: 'flow2' }] }
+      ])
 
     case 'flow2':
-      return fx(
-        { value: 100 },
-        {
-          log: { text: 'step2' },
-          dispatch: {
-            actions: [{ type: 'flow3' }]
-          }
-        }
-      )
+      return fx({ value: 100 }, [
+        { effect: 'log', text: 'step2' },
+        { effect: 'dispatch', actions: [{ type: 'flow3' }] }
+      ])
 
     case 'flow3':
-      return fx({ value: 1020 }, { log: { text: 'last' } })
+      return fx({ value: 1020 }, [{ effect: 'log', text: 'last' }])
 
     default:
       return state


### PR DESCRIPTION
The effects used to be a single map, keys being the effects id and values the params. This API
seemed a little weird,  especially when returning a batch of effects. (see #1 )
Now effects are represented by maps with a structure really close to a redux action, a  map with an effect key to identify the effect to run and potentially other keys to pass parameters to the handler. This makes returning a batch of effects simpler, the api simpler, more familiar to JS users, and easier to strongly type.

BREAKING CHANGE: Effects used to be a map like 

```
{ 
  effectKey: params, 
  effect2Key: params2 
}
```

it now should become an array of 
```
[
  { effect: 'effectKey', ...params },
  { effect: 'effect2Key', ...params2 }
]
```
